### PR TITLE
Add additional parameters devmode option

### DIFF
--- a/common_resources/kv/options_arma.kv
+++ b/common_resources/kv/options_arma.kv
@@ -139,7 +139,7 @@
 
     StringLabel:
         text: 'Additional parameters'
-        hint_text: '<full options>'
+        hint_text: '<separated by space>'
         settings_name: 'arma_additionalParameters'
 
 

--- a/common_resources/kv/options_arma.kv
+++ b/common_resources/kv/options_arma.kv
@@ -137,6 +137,11 @@
         text: 'No sound'
         settings_name: 'arma_noSound'
 
+    StringLabel:
+        text: 'Additional parameters'
+        hint_text: '<full options>'
+        settings_name: 'arma_additionalParameters'
+
 
     Label:
         text: 'Get all the torrent urls for:'

--- a/src/third_party/helpers.py
+++ b/src/third_party/helpers.py
@@ -331,6 +331,9 @@ def create_game_parameters():
     if settings.get('arma_exThreads') and settings.get('arma_exThreads_enabled'):
         args.append('-exThreads=' + settings.get('arma_exThreads'))
 
+    if settings.get('arma_additionalParameters'):
+        args.extend(settings.get('arma_additionalParameters').split())
+
     return args
 
 def get_mission_file_parameter():

--- a/src/third_party/helpers.py
+++ b/src/third_party/helpers.py
@@ -20,6 +20,7 @@ import os
 import teamspeak
 import textwrap
 import utils.system_processes
+import shlex
 
 from kivy.logger import Logger
 from third_party import steam
@@ -335,7 +336,7 @@ def create_game_parameters():
         args.append('-hugepages')
 
     if settings.get('arma_additionalParameters'):
-        args.extend(settings.get('arma_additionalParameters').split())
+        args.extend(shlex.split(settings.get('arma_additionalParameters')))
 
     return args
 

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -103,6 +103,7 @@ class Settings(Model):
         {'name': 'arma_exThreads', 'defaultValue': '0'},
         {'name': 'arma_exThreads_enabled', 'defaultValue': False},
         {'name': 'arma_noSound', 'defaultValue': False},
+        {'name': 'arma_additionalParameters', 'defaultValue': ''},
     ]
 
     # path to the registry entry which holds the users document path


### PR DESCRIPTION
**WIP**

- Add arbitrary Arma 3 startup parameters options
- Close #257 

Test run (fake path, using Frontline theme) with `-noLogs -enableHT` as additional parameters:
```
[INFO   ] [Arma        ] Running Arma: [C:\steam.exe, -applaunch, 107410, -nolauncher, -usebe, -nosplash, -skipIntro, -mod=C:\Frontline\@CUP Terrains - Core, -noLogs, -enableHT]
```