### PR TITLE
Add global BattlEye metadata option

### DIFF
--- a/src/sync/manager_functions.py
+++ b/src/sync/manager_functions.py
@@ -201,6 +201,10 @@ def parse_teamspeak_data(para, data):
 
     return teamspeak
 
+def parse_battleye_data(para, data):
+    battleye = data.get('battleye')
+
+    return battleye
 
 def parse_servers_data(para, data, launcher_moddir):
     servers = []
@@ -223,6 +227,7 @@ def parse_servers_data(para, data, launcher_moddir):
             server.add_mods(parse_mods_data(para, server_entry, launcher_moddir))
 
         server.teamspeak = parse_teamspeak_data(para, server_entry)
+        server.battleye = parse_battleye_data(para, server_entry)
 
         servers.append(server)
 
@@ -235,6 +240,7 @@ def _prepare_and_check(messagequeue, launcher_moddir, launcher_basedir,
     mods_list = parse_mods_data(messagequeue, mod_descriptions_data, launcher_moddir)
     servers_list = parse_servers_data(messagequeue, mod_descriptions_data, launcher_moddir)
     teamspeak = parse_teamspeak_data(messagequeue, mod_descriptions_data)
+    battleye = parse_battleye_data(messagequeue, mod_descriptions_data)
 
     # Set the selection flag near for all the mods that have been selected
     # by the user
@@ -274,6 +280,7 @@ def _prepare_and_check(messagequeue, launcher_moddir, launcher_basedir,
                           'launcher': launcher,
                           'servers': servers_list,
                           'teamspeak': teamspeak,
+                          'battleye': battleye,
                           })
 
 

--- a/src/sync/modmanager.py
+++ b/src/sync/modmanager.py
@@ -130,6 +130,7 @@ class ModManager(object):
     def run_the_game(self):
         server = self.get_selected_server()
         teamspeak = self.teamspeak
+        battleye = self.battleye
         mods = self.get_mods(only_selected=True)
 
         Logger.info('run_the_game: Running Arma 3 and connecting to server: {}'.format(server))
@@ -137,13 +138,15 @@ class ModManager(object):
         if server:
             if server.teamspeak:
                 teamspeak = server.teamspeak
+            if server.battleye is not None:
+                battleye = server.battleye
 
             third_party.helpers.run_the_game(mods,
                                              ip=server.ip,
                                              port=server.port,
                                              password=server.password,
                                              teamspeak_urls=teamspeak,
-                                             battleye=server.battleye)
+                                             battleye=battleye)
         else:
             third_party.helpers.run_the_game(mods,
                                              ip=None,
@@ -198,6 +201,7 @@ class ModManager(object):
         self.launcher = data['launcher']
         self.servers = data['servers']
         self.teamspeak = data['teamspeak']
+        self.battleye = data['battleye']
 
         Logger.info('ModManager: Got base mods:\n' + '\n'.join(repr(mod)for mod in self.mods))
         Logger.info('ModManager: Got servers:\n' + '\n'.join(repr(server) for server in self.servers))
@@ -207,6 +211,9 @@ class ModManager(object):
 
         if self.teamspeak:
             Logger.info('ModManager: Got base teamspeak:\n{}'.format(repr(self.teamspeak)))
+
+        if self.battleye is not None:
+            Logger.info('ModManager: Got base battleye:\n{}'.format(repr(self.battleye)))
 
     def sync_all(self, seed):
         synced_elements = self.get_mods(only_selected=True)  # Work on the copy


### PR DESCRIPTION
- Add global `"battleye": <bool>` server metadata option.
- Close #256 

Confirmed working on my test metadata. Both server query and running the game, with all combinations (global false, server false / global true, server false / global true, server false / global true server true).