### PR TITLE
Move No Pause option to standard options and set to enabled by default

### DIFF
--- a/common_resources/kv/options_arma.kv
+++ b/common_resources/kv/options_arma.kv
@@ -78,6 +78,10 @@
                 settings_name: 'arma_showScriptErrors'
 
             CheckLabel:
+                text: 'No pause'
+                settings_name: 'arma_noPause'
+
+            CheckLabel:
                 text: 'Force window mode'
                 settings_name: 'arma_window'
 
@@ -132,10 +136,6 @@
     CheckLabel:
         text: 'Check signatures at start'
         settings_name: 'arma_checkSignatures'
-
-    CheckLabel:
-        text: 'No pause'
-        settings_name: 'arma_noPause'
 
     CheckLabel:
         text: 'No sound'

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -92,7 +92,7 @@ class Settings(Model):
         {'name': 'arma_name', 'defaultValue': ''},
         {'name': 'arma_name_enabled', 'defaultValue': False},
         {'name': 'arma_showScriptErrors', 'defaultValue': False},
-        {'name': 'arma_noPause', 'defaultValue': False},
+        {'name': 'arma_noPause', 'defaultValue': True},
         {'name': 'arma_window', 'defaultValue': False},
         {'name': 'arma_checkSignatures', 'defaultValue': False},
         {'name': 'arma_filePatching', 'defaultValue': False},


### PR DESCRIPTION
- Move No Pause option to standard (non-devmode) options
- Default No Pause to true (prevents freezing game when out of focus)

"Pause" in this context simply means freezing the game simulation when game is out of focus. As soon as it's back in focus it starts simulating again. This is very unfriendly for people with Arma on main screen and other applications on secondary (or whatever) and want to interact with both. Additionally sound stops being played during this freeze.